### PR TITLE
Add: EnegyWebX mainnet and testnet config file

### DIFF
--- a/configs/energywebx.yml
+++ b/configs/energywebx.yml
@@ -1,0 +1,20 @@
+# Energy Web X on Pokadot Network (Energy Web X Mainnet)
+endpoint:
+  - wss://public-rpc.mainnet.energywebx.com
+  - wss://wnp-rpc.mainnet.energywebx.com
+  - wss://wns-rpc.mainnet.energywebx.com
+mock-signature-host: true
+block: ${env.ENERGYWBEX_BLOCK_NUMBER}
+db: ./ewx.db.sqlite
+# wasm-override: ew_parachain_runtime.compact.compressed.wasm
+
+runtime-log-level: 5
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: '50000000000000000000'

--- a/configs/energywebx.yml
+++ b/configs/energywebx.yml
@@ -10,11 +10,13 @@ db: ./ewx.db.sqlite
 
 runtime-log-level: 5
 import-storage:
+  Sudo:
+    Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
   System:
     Account:
       -
         -
-          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
         - providers: 1
           data:
             free: '50000000000000000000'

--- a/configs/pex.yml
+++ b/configs/pex.yml
@@ -1,0 +1,19 @@
+# Energy Web X on Paseo Network (Energy Web X Testnet)
+endpoint:
+  - wss://public-rpc.testnet.energywebx.com
+  - wss://wnp-rpc.testnet.energywebx.com
+mock-signature-host: true
+block: ${env.PEX_BLOCK_NUMBER}
+db: ./pex.db.sqlite
+# wasm-override: ew_parachain_runtime.compact.compressed.wasm
+
+runtime-log-level: 5
+import-storage:
+  System:
+    Account:
+      -
+        -
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+        - providers: 1
+          data:
+            free: '50000000000000000000'

--- a/configs/pex.yml
+++ b/configs/pex.yml
@@ -9,11 +9,13 @@ db: ./pex.db.sqlite
 
 runtime-log-level: 5
 import-storage:
+  Sudo:
+    Key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
   System:
     Account:
       -
         -
-          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+          - 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
         - providers: 1
           data:
             free: '50000000000000000000'


### PR DESCRIPTION
- Added configuration files for EnergyWebX and PEX networks.
- This PR enables the integration of EnergyWebX and PEX networks into the Chopstick CLI.
- The Chopstick CLI no longer requires a config file to be provided explicitly; specifying the network name will trigger the necessary execution.
  - Use `npx @acala-network/chopsticks@latest -c energywebx` instead of `npx @acala-network/chopsticks@latest -c=energywebx.yml`
- Discoveries have been added to the [Ticket](https://energyweb.atlassian.net/browse/EWX-770)